### PR TITLE
Enable to specify running port

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ $ npm i
 ```
 $ npm start
 ```
+
+Also you can specify access port like below (default is 3000).
+
+```
+PORT=3001 npm start
+```
+
 2. Access http://localhost:3000/ on browser.
 3. Input urls in the textarea and click the CHECK button.
 

--- a/app/app.js
+++ b/app/app.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const client = require('cheerio-httpcli');
 const bodyParser = require('body-parser');
+const port = process.env.PORT || 3000;
 
 const app = express();
 
@@ -12,7 +13,7 @@ app.use(express.static('./app/public'));
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
 
-const server = app.listen(3000, () => {
+const server = app.listen(port, () => {
   /* eslint-disable no-console */
   console.log(`Node.js is listening to PORT:${server.address().port}`);
   /* eslint-enable no-console */


### PR DESCRIPTION
## Description
Enable to specify  access port using environment variable.

```sh
$ PORT=3001 npm start

> ogimg-checker@1.0.0 start /Users/yusuke/work/ogimage-checker
> node app/app.js

Node.js is listening to PORT:3001
```

## Motivation and Context
I wanted to check my app's og image, but my app is also running on 3000.